### PR TITLE
2D grid blocks for renderer

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,9 +99,12 @@ extern "C"
 {
 __global__ void render(const float* inps, const unsigned int* board, int* scrn)
     {
+        unsigned int i = (blockIdx.x * blockDim.x) + threadIdx.x;
+        unsigned int j = (blockIdx.y * blockDim.y) + threadIdx.y;
         unsigned int indx = (blockDim.x * blockIdx.x) + threadIdx.x;
+        unsigned int resx = *(inps + );
         // unsigned int lim = ;
-        if (indx < *(inps + 6))
+        if (indx < j + (i * resx)) //LEFT HERE
         {
             float bx = 0;
             float by = 0;
@@ -241,7 +244,7 @@ def renderer():
                      bh,
                      int(scrw * scrsplit * scrh),
                      ], dtype=cp.float32)
-    rendergpu((int(scrw * scrsplit),), (scrh,),
+    rendergpu((int((scrw * scrsplit) / 32),int(scrh / 16)), (32, 16),
               (args,
                board_gpu,
                screenarr))

--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,5 @@ Python project to simulate Cellular automation. <br>
 GPU accelerated rendering(CuPY), GPU-based game update(CuPY), Interactive gamestates(PyGame-CE), customizable view (PyGame-CE), Saving game state evolution as a recording (openCV).
 <br>
 Some of these features are yet to be implemented.
+
+Master is the main branch, with working code; alpha is the staging branch.

--- a/testfile.py
+++ b/testfile.py
@@ -11,17 +11,16 @@ screen = pygame.display.set_mode((1120, 800))
 loaded_from_source = r'''
 extern "C"
 {
-__global__ void test_sum(int* y, const unsigned int arrxsize)
+__global__ void test_sum(int* y ) //, const unsigned int arrxsize)
     {
-    //unsigned int tid = (blockDim.x * (blockIdx.x + (blockDim.x * blockIdx.y))) + (threadIdx.x + (threadDim.x * threadIdx.y);
-    //unsigned int tn = threadIdx.x + (threadDim.x * threadIdx.y);
-    //unsigned int bn = blockIdx.x + (blockDim.x * blockIdx.y);
     unsigned int i = (blockIdx.x * blockDim.x) + threadIdx.x;
     unsigned int j = (blockIdx.y * blockDim.y) + threadIdx.y;
-    unsigned int tid = j + (i * arrxsize);
+    unsigned int ylim = gridDim.y * blockDim.y;
+    unsigned int tid = j + (i * ylim);
+    unsigned int xlim = gridDim.x * blockDim.x;
     unsigned int py = j;
     unsigned int px = i;
-        if (tid < 1120 * 800)
+        if (tid < xlim * ylim)
         {
             if(px > 300)
             {


### PR DESCRIPTION
Renderer call is now resolution agnostic. But scrw * scrsplit and scrh should both be set and should be a multiple of 32 and 16 respectively.